### PR TITLE
feat: Version 1.1.2-BETA - Nether and Config Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.jeqo</groupId>
     <artifactId>bloons</artifactId>
-    <version>1.1.1-BETA</version>
+    <version>1.1.2-BETA</version>
     <packaging>jar</packaging>
 
     <name>Bloons</name>

--- a/src/main/java/net/jeqo/bloons/Bloons.java
+++ b/src/main/java/net/jeqo/bloons/Bloons.java
@@ -4,11 +4,8 @@ import lombok.Getter;
 import lombok.Setter;
 import net.jeqo.bloons.balloon.SingleBalloon;
 import net.jeqo.bloons.commands.manager.CommandCore;
+import net.jeqo.bloons.listeners.*;
 import net.jeqo.bloons.utils.UpdateChecker;
-import net.jeqo.bloons.listeners.BalloonUnleashListener;
-import net.jeqo.bloons.listeners.ListenerCore;
-import net.jeqo.bloons.listeners.BalloonMenuListener;
-import net.jeqo.bloons.listeners.BalloonPlayerListener;
 import net.jeqo.bloons.logger.Logger;
 import net.jeqo.bloons.utils.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -45,6 +42,7 @@ public final class Bloons extends JavaPlugin {
         getListenerCore().stageListener(new BalloonPlayerListener());
         getListenerCore().stageListener(new BalloonUnleashListener());
         getListenerCore().stageListener(new BalloonMenuListener());
+        getListenerCore().stageListener(new BalloonEntityListener());
 
         // Register all handlers
         getListenerCore().registerListeners();

--- a/src/main/java/net/jeqo/bloons/listeners/BalloonEntityListener.java
+++ b/src/main/java/net/jeqo/bloons/listeners/BalloonEntityListener.java
@@ -1,0 +1,21 @@
+package net.jeqo.bloons.listeners;
+
+import net.jeqo.bloons.configuration.BalloonConfiguration;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPortalEvent;
+
+public class BalloonEntityListener implements Listener {
+
+    /**
+     * Stop the chicken from going through the portal to prevent unleashing from player to balloon
+     * @param event The event that is called when an entity goes through a portal
+     */
+    @EventHandler
+    public void onChickenPortalLeave(EntityPortalEvent event) {
+        if (event.getEntity().getCustomName() != null && event.getEntity().getCustomName().contains(BalloonConfiguration.BALLOON_CHICKEN_ID)) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/src/main/java/net/jeqo/bloons/listeners/BalloonPlayerListener.java
+++ b/src/main/java/net/jeqo/bloons/listeners/BalloonPlayerListener.java
@@ -2,6 +2,7 @@ package net.jeqo.bloons.listeners;
 
 import net.jeqo.bloons.Bloons;
 import net.jeqo.bloons.balloon.SingleBalloon;
+import net.jeqo.bloons.configuration.BalloonConfiguration;
 import net.jeqo.bloons.events.balloon.SingleBalloonForceUnequipEvent;
 import net.jeqo.bloons.events.balloon.SingleBalloonStoreEvent;
 import net.jeqo.bloons.utils.UpdateChecker;
@@ -10,11 +11,14 @@ import net.jeqo.bloons.utils.BalloonManagement;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityPortalEnterEvent;
+import org.bukkit.event.entity.EntityPortalEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Objects;
 

--- a/src/main/java/net/jeqo/bloons/listeners/BalloonUnleashListener.java
+++ b/src/main/java/net/jeqo/bloons/listeners/BalloonUnleashListener.java
@@ -3,7 +3,9 @@ package net.jeqo.bloons.listeners;
 import net.jeqo.bloons.configuration.BalloonConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityUnleashEvent;
 import org.bukkit.event.entity.PlayerLeashEntityEvent;
+import org.bukkit.event.player.PlayerUnleashEntityEvent;
 
 public class BalloonUnleashListener implements Listener {
 
@@ -16,4 +18,15 @@ public class BalloonUnleashListener implements Listener {
             event.setCancelled(true);
         }
     }
+
+    @EventHandler
+    public void onUnleash(PlayerUnleashEntityEvent event) {
+        if (event.getReason() == EntityUnleashEvent.UnleashReason.PLAYER_UNLEASH) {
+            if (event.getEntity().getCustomName() != null && event.getEntity().getCustomName().contains(BalloonConfiguration.BALLOON_CHICKEN_ID)) {
+                event.setCancelled(true);
+            }
+        }
+    }
+
+
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,6 +1,6 @@
 # --------------------------------------------------#
 #
-# Bloons 1.1.1-BETA
+# Bloons 1.1.2-BETA
 # Made by Jeqo
 #
 # Wiki:     https://jeqo.net/wiki/bloons
@@ -77,7 +77,7 @@ balloons:
     id: blue
     permission: balloon.blue
     material: FLINT
-    custom-model-data: 5
+    custom-model-data: 4
     name: '<blue>Blue <white>Balloon'
     lore:
       - '&8Bloons Default Balloon'
@@ -87,7 +87,7 @@ balloons:
     id: green
     permission: balloon.green
     material: FLINT
-    custom-model-data: 6
+    custom-model-data: 5
     name: '<green>Green <white>Balloon'
     lore:
       - '&8Bloons Default Balloon'
@@ -97,7 +97,7 @@ balloons:
     id: pink
     permission: balloon.pink
     material: FLINT
-    custom-model-data: 7
+    custom-model-data: 6
     name: '<light_purple>Pink <white>Balloon'
     lore:
       - '&8Bloons Default Balloon'
@@ -107,7 +107,7 @@ balloons:
     id: yellow
     permission: balloon.yellow
     material: FLINT
-    custom-model-data: 8
+    custom-model-data: 7
     name: '<yellow>Yellow <white>Balloon'
     lore:
       - '&8Bloons Default Balloon'


### PR DESCRIPTION
# Description
- Bump version to version 1.1.2 in config and pom.xml
- Create a fix for nether portal chicken unleashing
- Update config custom model data values
- Move entity listeners to separate class

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested on a version 1.20.4 PaperMC Minecraft server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes

The updated [Bloons-Resource-Pack-2.0.zip](https://github.com/user-attachments/files/15754465/Bloons-Resource-Pack-2.0.zip) can be found by clicking on the hyperlink, this conforms with the version 1.20.4 version update and the custom model data value changes.