### PR TITLE
Multipart Balloon Sine Wave Configurations

### DIFF
--- a/src/main/java/net/jeqo/bloons/balloon/BalloonCore.java
+++ b/src/main/java/net/jeqo/bloons/balloon/BalloonCore.java
@@ -44,6 +44,8 @@ public class BalloonCore {
     public void initialize() {
         ConfigurationSection multipartBalloonsSection = Bloons.getInstance().getConfig().getConfigurationSection("multipart-balloons");
 
+        this.getBalloons().clear();
+
         if (multipartBalloonsSection == null) {
             return;
         }
@@ -68,6 +70,9 @@ public class BalloonCore {
                     keySection.getDouble("max-node-joint-angle"),
                     keySection.getDouble("y-axis-interpolation"),
                     keySection.getDouble("turning-spline-interpolation"),
+                    keySection.getDouble("passive-sine-wave-speed"),
+                    keySection.getDouble("passive-sine-wave-amplitude"),
+                    keySection.getDouble("passive-nose-sine-wave-amplitude"),
                     new MultipartBalloonModel(BalloonModelType.HEAD, keySection.getString("head.material"), keySection.getString("head.color"), keySection.getInt("head.custom-model-data")),
                     new MultipartBalloonModel(BalloonModelType.BODY, keySection.getString("body.material"), keySection.getString("body.color"), keySection.getInt("body.custom-model-data")),
                     new MultipartBalloonModel(BalloonModelType.TAIL, keySection.getString("tail.material"), keySection.getString("tail.color"), keySection.getInt("tail.custom-model-data")));

--- a/src/main/java/net/jeqo/bloons/balloon/multipart/MultipartBalloonType.java
+++ b/src/main/java/net/jeqo/bloons/balloon/multipart/MultipartBalloonType.java
@@ -21,9 +21,72 @@ public class MultipartBalloonType {
     private double maxNodeJointAngle = 35.0;
     private double yAxisInterpolation = 0.35;
     private double turningSplineInterpolation = 0.35;
+    private double passiveSineWaveSpeed = 0.05;
+    private double passiveSineWaveAmplitude = 0.5;
+    private double passiveNoseSineWaveAmplitude = 0.5;
     private MultipartBalloonModel headModel;
     private MultipartBalloonModel bodyModel;
     private MultipartBalloonModel tailModel;
+
+    public MultipartBalloonType(String id, String permission, String name, String[] lore, int nodeCount, double distanceBetweenNodes, double headNodeOffset, double bodyNodeOffset, double tailNodeOffset, double maxNodeJointAngle, double yAxisInterpolation, double turningSplineInterpolation, double passiveSineWaveSpeed, double passiveSineWaveAmplitude, double passiveNoseSineWaveAmplitude, MultipartBalloonModel headModel, MultipartBalloonModel bodyModel, MultipartBalloonModel tailModel) {
+        this.setId(id);
+        this.setPermission(permission);
+        this.setName(name);
+        this.setLore(lore);
+        this.setNodeCount(nodeCount);
+        this.setDistanceBetweenNodes(distanceBetweenNodes);
+        this.setHeadNodeOffset(headNodeOffset);
+        this.setBodyNodeOffset(bodyNodeOffset);
+        this.setTailNodeOffset(tailNodeOffset);
+        this.setMaxNodeJointAngle(maxNodeJointAngle);
+        this.setYAxisInterpolation(yAxisInterpolation);
+        this.setTurningSplineInterpolation(turningSplineInterpolation);
+        this.setPassiveSineWaveSpeed(passiveSineWaveSpeed);
+        this.setPassiveSineWaveAmplitude(passiveSineWaveAmplitude);
+        this.setPassiveNoseSineWaveAmplitude(passiveNoseSineWaveAmplitude);
+        this.setHeadModel(headModel);
+        this.setBodyModel(bodyModel);
+        this.setTailModel(tailModel);
+    }
+
+    public MultipartBalloonType(String id, String permission, String name, String[] lore, int nodeCount, double distanceBetweenNodes, double headNodeOffset, double bodyNodeOffset, double tailNodeOffset, double maxNodeJointAngle, double yAxisInterpolation, double turningSplineInterpolation, double passiveSineWaveSpeed, double passiveSineWaveAmplitude, MultipartBalloonModel headModel, MultipartBalloonModel bodyModel, MultipartBalloonModel tailModel) {
+        this.setId(id);
+        this.setPermission(permission);
+        this.setName(name);
+        this.setLore(lore);
+        this.setNodeCount(nodeCount);
+        this.setDistanceBetweenNodes(distanceBetweenNodes);
+        this.setHeadNodeOffset(headNodeOffset);
+        this.setBodyNodeOffset(bodyNodeOffset);
+        this.setTailNodeOffset(tailNodeOffset);
+        this.setMaxNodeJointAngle(maxNodeJointAngle);
+        this.setYAxisInterpolation(yAxisInterpolation);
+        this.setTurningSplineInterpolation(turningSplineInterpolation);
+        this.setPassiveSineWaveSpeed(passiveSineWaveSpeed);
+        this.setPassiveSineWaveAmplitude(passiveSineWaveAmplitude);
+        this.setHeadModel(headModel);
+        this.setBodyModel(bodyModel);
+        this.setTailModel(tailModel);
+    }
+
+    public MultipartBalloonType(String id, String permission, String name, String[] lore, int nodeCount, double distanceBetweenNodes, double headNodeOffset, double bodyNodeOffset, double tailNodeOffset, double maxNodeJointAngle, double yAxisInterpolation, double turningSplineInterpolation, double passiveSineWaveSpeed, MultipartBalloonModel headModel, MultipartBalloonModel bodyModel, MultipartBalloonModel tailModel) {
+        this.setId(id);
+        this.setPermission(permission);
+        this.setName(name);
+        this.setLore(lore);
+        this.setNodeCount(nodeCount);
+        this.setDistanceBetweenNodes(distanceBetweenNodes);
+        this.setHeadNodeOffset(headNodeOffset);
+        this.setBodyNodeOffset(bodyNodeOffset);
+        this.setTailNodeOffset(tailNodeOffset);
+        this.setMaxNodeJointAngle(maxNodeJointAngle);
+        this.setYAxisInterpolation(yAxisInterpolation);
+        this.setTurningSplineInterpolation(turningSplineInterpolation);
+        this.setPassiveSineWaveSpeed(passiveSineWaveSpeed);
+        this.setHeadModel(headModel);
+        this.setBodyModel(bodyModel);
+        this.setTailModel(tailModel);
+    }
 
     public MultipartBalloonType(String id, String permission, String name, String[] lore, int nodeCount, double distanceBetweenNodes, double headNodeOffset, double bodyNodeOffset, double tailNodeOffset, double maxNodeJointAngle, double yAxisInterpolation, double turningSplineInterpolation, MultipartBalloonModel headModel, MultipartBalloonModel bodyModel, MultipartBalloonModel tailModel) {
         this.setId(id);

--- a/src/main/java/net/jeqo/bloons/balloon/multipart/balloon/MultipartBalloon.java
+++ b/src/main/java/net/jeqo/bloons/balloon/multipart/balloon/MultipartBalloon.java
@@ -94,9 +94,9 @@ public class MultipartBalloon {
         }
 
         long timeInTicks = 1;
-        double speed = 0.05; // Adjust the speed of the sine wave
-        double amplitude = 0.5; // Adjust the amplitude of the sine wave
-        double noseAmplitude = 0.5; // Adjust how much the nose of the first node goes up and down
+        double speed = this.getBalloonType().getPassiveSineWaveSpeed(); // Adjust the speed of the sine wave
+        double amplitude = this.getBalloonType().getPassiveSineWaveAmplitude(); // Adjust the amplitude of the sine wave
+        double noseAmplitude = this.getBalloonType().getPassiveNoseSineWaveAmplitude(); // Adjust how much the nose of the first node goes up and down
 
         this.setRunnable(new BukkitRunnable() {
             double yOffset = 0; // Initial offset for the sine curve

--- a/src/main/java/net/jeqo/bloons/commands/CommandReload.java
+++ b/src/main/java/net/jeqo/bloons/commands/CommandReload.java
@@ -33,6 +33,8 @@ public class CommandReload extends Command {
         Bloons.getInstance().getConfig().options().copyDefaults();
         Bloons.getInstance().saveDefaultConfig();
 
+        Bloons.getBalloonCore().initialize(); // Refresh balloons and their configurations
+
         Component configReloadedMessage = messageTranslations.getSerializedString(messageTranslations.getMessage("prefix"), messageTranslations.getMessage("config-reloaded"));
         sender.sendMessage(configReloadedMessage);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -145,6 +145,9 @@ multipart-balloons:
     max-joint-angle: 35.0 # The max angle in degrees of freedom for each joint between nodes
     y-axis-interpolation: 0.2 # The amount of interpolation between nodes on the Y axis (must be between 0.0 and 1.0)
     turning-spline-interpolation: 0.5 # The amount of interpolation for the spline when turning
+    passive-sine-wave-speed: 0.05
+    passive-sine-wave-amplitude: 0.5
+    passive-nose-sine-wave-amplitude: 0.5
     head: # Head must be supplied for a balloon of this kind
       material: LEATHER_HORSE_ARMOR # The material of the head
       color: '#FF0000' # The color of the head item, this is optional


### PR DESCRIPTION
Fixed reloading commands, now initializes balloon core

# Description
Implemented multipart balloon configurations to modify passive sine wave functionality
Fixed the reload command, it now reloads and reinitializes the balloons registered in the balloon core.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
It was tested on a version 1.20.4 PaperMC server

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation, if any
- [x] My changes generate no new warnings
- [x] I have performed tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes